### PR TITLE
Changing FOUNDRY_CACHE to true

### DIFF
--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -143,7 +143,7 @@ function forgeBuildTask(file: string) {
         'FOUNDRY_EXTRA_OUTPUT': '["storageLayout", "evm.bytecode.generatedSources"]',
         'FOUNDRY_BYTECODE_HASH': 'ipfs',
         'FOUNDRY_CBOR_METADATA': 'true',
-        'FOUNDRY_CACHE': incrementalBuild ? 'true' : 'false',
+        'FOUNDRY_CACHE': 'true',
       }
     })
   );


### PR DESCRIPTION
When setting `FOUNDRY_CACHE` to false, the `build_info` folder would not be generated, leading to issues during the debugging process on the Simbolik server.