### PR TITLE
Isolate anvil node per debugging session

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,9 +26,6 @@ export function activate(context: vscode.ExtensionContext) {
   if (getConfigValue('simbolik-autostart', true)) {
     supervisor.simbolik();
   }
-  //if (getConfigValue('anvil-autostart', true)) {
-  //  supervisor.anvil();
-  //}
   context.subscriptions.push(supervisor);
 
   const codelensProvider = new CodelensProvider();
@@ -47,7 +44,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   disposable = vscode.commands.registerCommand(
     'simbolik.startDebugging',
-    startDebugging
+    startDebugging,
+    supervisor
   );
   context.subscriptions.push(disposable);
 
@@ -62,6 +60,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.debug.onDidStartDebugSession(session => {
     outputChannel.info(`Debug session started: ${session.id}`);
+  });
+
+  vscode.debug.onDidTerminateDebugSession(session => {
+    supervisor.anvilTerminate();
+    outputChannel.info(`Debug session ended: ${session.id}`);
   });
 }
 

--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -9,12 +9,13 @@ import {getConfigValue} from './utils';
 import {Supervisor} from './supevervisor';
 
 export async function startDebugging(
+  this: Supervisor,
   contract: ContractDefinition,
   method: FunctionDefinition
 ) {
-  const supervisor = new Supervisor();
   if (getConfigValue('anvil-autostart', true)) {
-    supervisor.anvil();
+    this.anvilTerminate();
+    this.anvil();
   }
   const activeTextEditor = vscode.window.activeTextEditor;
   if (!activeTextEditor) {
@@ -90,7 +91,6 @@ export async function startDebugging(
       myDebugConfig
     );
   }
-  supervisor.anvilTerminate();
 }
 
 function completed(tastkExecution: vscode.TaskExecution): Promise<void> {

--- a/src/supevervisor.ts
+++ b/src/supevervisor.ts
@@ -11,7 +11,7 @@ export class Supervisor {
       vscode.window.showErrorMessage('Anvil failed to start');
     }
     vscode.tasks.onDidEndTaskProcess(async e => {
-      if (e.execution === this._anvil) {
+      if (e.execution === this._anvil && e.exitCode !== undefined) {
         this._anvil?.terminate();
         this._anvil = undefined;
         const action = await vscode.window.showErrorMessage(


### PR DESCRIPTION
The anvil node is launched when the extension is activated and shared by all debugging sessions. When inspecting the cold storage, one can see that there are as many addresses for the contract being debugged as many debugging sessions (even the ones already finished appear in the cold storage of debugging sessions created afterward). This PR launches the anvil node when the debugging session starts and shuts it down when the session finishes. Therefore, all debugging sessions have their own isolated anvil node, and the cold storage issue was fixed. 