### PR TITLE
Replace TOML parser.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"${workspaceFolder}/../simbolik-examples"
+				"${workspaceFolder}/sampleWorkspace"
 			],
 			"outFiles": [
 				"${workspaceFolder}/build/*.js",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"${workspaceFolder}/sampleWorkspace"
+				"${workspaceFolder}/../simbolik-examples"
 			],
 			"outFiles": [
 				"${workspaceFolder}/build/*.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "Simbolik VSCode" extension will be documented in this file.
 
+## [2.0.3] - 2024-05-28
+
+- Fixed a bug in the TOML parser
+
 ## [2.0.2] - 2024-05-27
 
 - Added information about the Simbolik API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "simbolik",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simbolik",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dependencies": {
         "@solidity-parser/parser": "^0.18.0",
         "@types/ws": "^8.5.10",
-        "toml": "^3.0.0",
+        "smol-toml": "^1.2.0",
         "ws": "^8.16.0"
       },
       "devDependencies": {
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001623",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001623.tgz",
-      "integrity": "sha512-X/XhAVKlpIxWPpgRTnlgZssJrF0m6YtRA0QDWgsBNT12uZM6LPRydR7ip405Y3t1LamD8cP2TZFEDZFBf5ApcA==",
+      "version": "1.0.30001624",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
+      "integrity": "sha512-0dWnQG87UevOCPYaOR49CBcLBwoZLpws+k6W37nLjWUhumP1Isusj0p2u+3KhjNloRWK9OKMgjBBzPujQHw4nA==",
       "dev": true,
       "funding": [
         {
@@ -4164,6 +4164,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.2.0.tgz",
+      "integrity": "sha512-KObxdQANC/xje3OoatMbSwQf2XAvJ0RbK+4nmQRszFNZptbNRnMWqbLF/zb4sMi9xJ6HNyhWXeuZ9zC/I/XY7w==",
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 9"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -4448,11 +4457,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simbolik",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simbolik",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@solidity-parser/parser": "^0.18.0",
         "@types/ws": "^8.5.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "publisher": "runtimeverification",
   "description": "Advanced Solidity and EVM Debugger",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   "dependencies": {
     "@solidity-parser/parser": "^0.18.0",
     "@types/ws": "^8.5.10",
-    "ws": "^8.16.0",
-    "toml": "^3.0.0"
+    "smol-toml": "^1.2.0",
+    "ws": "^8.16.0"
   }
 }

--- a/src/foundry.ts
+++ b/src/foundry.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import {getConfigValue} from './utils';
-import {parse as parseToml} from 'toml';
+import {parse as parseToml} from 'smol-toml';
 
 
 export

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build",
-    "lib": ["ES2020"],
-    "target": "ES2020"
+    "lib": ["ES2022"],
+    "target": "ES2022"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
There is a bug in the TOML library we use to parse the foundry.toml file: https://github.com/BinaryMuse/toml-node/issues/46

This PR replaces the parser with [smol-toml](https://github.com/squirrelchat/smol-toml), which is more robust.