### PR TITLE
Added forge clean task

### DIFF
--- a/src/foundry.ts
+++ b/src/foundry.ts
@@ -2,6 +2,26 @@ import * as vscode from 'vscode';
 import {getConfigValue} from './utils';
 import {parse as parseToml} from 'smol-toml';
 
+export
+function forgeCleanTask(file: string) {
+  const forgePath = getConfigValue('forge-path', 'forge');
+  const cwd = file.substring(0, file.lastIndexOf('/'));
+  const task = new vscode.Task(
+    {
+      label: 'forge clean',
+      type: 'shell',
+    },
+    vscode.TaskScope.Workspace,
+    'forge',
+    'simbolik',
+    new vscode.ShellExecution(forgePath, ['clean'], {
+      cwd,
+    })
+  );
+  task.isBackground = true;
+  task.presentationOptions.reveal = vscode.TaskRevealKind.Always;
+  return task;
+}
 
 export
 function forgeBuildTask(file: string) {

--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -7,7 +7,7 @@ import {
 import * as vscode from 'vscode';
 import { getConfigValue } from './utils';
 import { Supervisor } from './supevervisor';
-import { forgeBuildTask, foundryRoot, loadBuildInfo } from './foundry';
+import { forgeCleanTask, forgeBuildTask, foundryRoot, loadBuildInfo } from './foundry';
 
 export async function startDebugging(
   this: Supervisor,
@@ -63,6 +63,13 @@ export async function startDebugging(
   const rpcUrl = `http://localhost:${anvilPort}`;
   const autobuild = getConfigValue('autobuild', true);
   if (autobuild) {
+    const clean = forgeCleanTask(activeTextEditor.document.uri.fsPath);
+    const cleanExecution = await vscode.tasks.executeTask(clean);
+    try {
+      await completed(cleanExecution);
+    } catch (e) {
+      vscode.window.showErrorMessage('Failed to clean project.');
+    }
     const build = forgeBuildTask(activeTextEditor.document.uri.fsPath);
     const buildExecution = await vscode.tasks.executeTask(build);
     try {


### PR DESCRIPTION
In some cases, when there are previous build artifacts in the `out/` directory, the debugger behaves unexpectedly. This PR runs `forge clean` before running `forge build` for each debugging session that has the `auto build` flag set to `true`. 