### PR TITLE
Remove stop-at-first-opcode option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "Simbolik VSCode" extension will be documented in this file.
 
+## [7.0.0] - 2025-03-06
+
+- Removed support for the `stop-at-first-opcode` option in the extension settings. \
+  With time-travel debugging there is a simpler way to achieve the same effect.
+
 ## [6.0.2] - 2025-03-03
 
 - Automatically prompts users without API keys to authenticate via GitHub

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "publisher": "runtimeverification",
   "description": "Advanced Solidity and EVM Debugger",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/package.json
+++ b/package.json
@@ -81,12 +81,6 @@
           "description": "Chose when Simbolik should build the project.",
           "order": 3
         },
-        "simbolik.stop-at-first-opcode": {
-          "type": "boolean",
-          "description": "If set to true, the debugger will stop at the first opcode. Otherwise it will stop at the function entry. Disabling this option is experimental and may lead to unexpected behavior.",
-          "default": true,
-          "order": 5
-        },
         "simbolik.show-sourcemaps": {
           "type": "boolean",
           "default": false,

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -88,7 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
         "txHash": txHash,
         "jsonRpcUrl": `https://rpc.buildbear.io/${sandboxName}`,
         "sourcifyUrl": `https://rpc.buildbear.io/verify/sourcify/server/${sandboxName}`,
-        "stopAtFirstOpcode": true,
+        "stopAtFirstOpcode": false,
         "chainId": chainId,
       }
       vscode.debug.startDebugging(

--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -81,7 +81,6 @@ export async function startDebugging(
     const file = activeTextEditor.document.uri.toString();
     const contractName = contract['name'];
     const methodSignature = `${method['name']}(${parameters.join(',')})`;
-    const stopAtFirstOpcode = getConfigValue('stop-at-first-opcode', true);
     const showSourcemaps = getConfigValue('show-sourcemaps', false);
     const debugConfigName = `${contractName}.${methodSignature}`;
     const jsonRpcUrl = getConfigValue('json-rpc-url', 'http://localhost:8545');
@@ -131,7 +130,6 @@ export async function startDebugging(
       file,
       contractName,
       methodSignature,
-      stopAtFirstOpcode,
       showSourcemaps,
       jsonRpcUrl,
       sourcifyUrl,
@@ -167,7 +165,6 @@ function debugConfig(
   file: string,
   contractName: string,
   methodSignature: string,
-  stopAtFirstOpcode: boolean,
   showSourcemaps: boolean,
   jsonRpcUrl: string,
   sourcifyUrl: string,
@@ -182,7 +179,7 @@ function debugConfig(
     file: file,
     contractName: contractName,
     methodSignature: methodSignature,
-    stopAtFirstOpcode: stopAtFirstOpcode,
+    stopAtFirstOpcode: false,
     showSourcemaps: showSourcemaps,
     jsonRpcUrl: jsonRpcUrl,
     sourcifyUrl: sourcifyUrl,


### PR DESCRIPTION
Since we have a more integrated solution to reach the first opcode with time-travel debugging, we're removing the `stop-at-first-opcode` configuration option.