### PR TITLE
Check if release exists before creating a new one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
           skipDuplicate: true
       - name: Attach vsix to release
         uses: actions/upload-release-asset@v1
+        if: steps.get_release.outputs.exists == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,14 @@ jobs:
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
+          skipDuplicate: true
       - name: Publish extension to Open VSX
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           extensionFile: ${{ steps.create_vsix.outputs.vsixPath }}
           packagePath: ''
+          skipDuplicate: true
       - name: Attach vsix to release
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,29 @@ jobs:
         with:
           version: ${{ steps.package_version.outputs.current-version }}
           path: 'CHANGELOG.md'
+      - name: Check if release already exists
+        id: get_release
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            try {
+              const rel = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: process.env.VERSION
+              });
+              core.setOutput('exists', 'true');
+              core.setOutput('upload_url', rel.data.upload_url);
+            } catch (e) {
+              if (e.status === 404) core.setOutput('exists', 'false');
+              else throw e;
+            }
+        env:
+          VERSION: ${{ steps.package_version.outputs.current-version }}
       - name: Create a Release
         id: create_release
+        if: steps.get_release.outputs.exists == 'false'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR checks if a GitHub release already exists before creating a new release.
This is needed to avoid the following deadlock:

1. We trigger the "release" workflow
2. The workflow passes the "Create a Release" step
3. The workflow fails in a later step (e.g., due the flakiness of the VSX registry or the VSCode marketplace)
4. We rerun the workflow
5. The workflow now fails in the "Create a Release" because it already exists

This happened just now: https://github.com/runtimeverification/simbolik-vscode/actions/runs/16137751602