### PR TITLE
Always use the most recent test tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "Simbolik VSCode" extension will be documented in this file.
 
+## [15.0.1] - 2026-03-25
+
+- Fixed a bug, that caused test runs to fail after refreshing the test explorer view
+
 ## [15.0.0] - 2026-03-23
 
 - Simbolik now allows inspecting mappings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simbolik",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simbolik",
-      "version": "15.0.0",
+      "version": "15.0.1",
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
         "@metamask/abi-utils": "^3.0.0",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.323",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.323.tgz",
+      "integrity": "sha512-oQm+FxbazvN2WICCbvJgj3IYPKV8awip57+W5VP+Aatk4kFU4pDYCPHZOX22Z27zpw8uttBehEqgK+VTJAYrVw==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -5745,9 +5745,9 @@
       "license": "0BSD"
     },
     "node_modules/tapable": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.1.tgz",
-      "integrity": "sha512-b+u3CEM6FjDHru+nhUSjDofpWSBp2rINziJWgApm72wwGasQ/wKXftZe4tI2Y5HPv6OpzXSZHOFq87H4vfsgsw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "publisher": "runtimeverification",
   "description": "Advanced Solidity and EVM Debugger",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "engines": {
     "vscode": "^1.79.0",
     "node": ">=16.0.0"

--- a/src/TestAdapter.ts
+++ b/src/TestAdapter.ts
@@ -44,14 +44,19 @@ export async function createTestController(): Promise<vscode.TestController> {
     tag('debug')
   );
 
-  createFoundryProfile(testController, testTree, vscode.TestRunProfileKind.Run);
+  const getTestTree = () => testTree;
+  createFoundryProfile(
+    testController,
+    getTestTree,
+    vscode.TestRunProfileKind.Run
+  );
   const coverageCache: WeakMap<
     vscode.FileCoverage,
     vscode.StatementCoverage[]
   > = new WeakMap();
   const coverageProfile = createFoundryProfile(
     testController,
-    testTree,
+    getTestTree,
     vscode.TestRunProfileKind.Coverage,
     coverageCache
   );
@@ -131,7 +136,7 @@ class IndexedTestTree {
 
 function createFoundryProfile(
   testController: vscode.TestController,
-  testTree: IndexedTestTree,
+  getTestTree: () => IndexedTestTree,
   profileKind: vscode.TestRunProfileKind,
   coverageCache?: WeakMap<vscode.FileCoverage, vscode.StatementCoverage[]>
 ) {
@@ -141,6 +146,7 @@ function createFoundryProfile(
       : 'Run Tests with Coverage',
     profileKind,
     async (request, token) => {
+      const testTree = getTestTree();
       const run = testController.createTestRun(request);
       for (const item of request.include ?? []) {
         if (token.isCancellationRequested) {


### PR DESCRIPTION
This PR fixes a bug that caused test runs to fail after the user requested to update the test tree.